### PR TITLE
Feat: Consolidate notification queues, add idempotency cache, implement TODO handlers

### DIFF
--- a/internal/handlers/application.go
+++ b/internal/handlers/application.go
@@ -13,12 +13,10 @@ import (
 // ApplicationRequestedHandler handles APPLICATION_REQUESTED events
 type ApplicationRequestedHandler struct{}
 
-// NewApplicationRequestedHandler creates a new ApplicationRequestedHandler
 func NewApplicationRequestedHandler() *ApplicationRequestedHandler {
 	return &ApplicationRequestedHandler{}
 }
 
-// Handle processes an APPLICATION_REQUESTED event
 func (h *ApplicationRequestedHandler) Handle(ctx context.Context, b *bot.DiscordBot, guildID string, payload map[string]interface{}) (map[string]interface{}, error) {
 	return handleApplicationNotification(b, payload, bot.StatusRequested)
 }
@@ -26,12 +24,10 @@ func (h *ApplicationRequestedHandler) Handle(ctx context.Context, b *bot.Discord
 // ApplicationAcceptedHandler handles APPLICATION_ACCEPTED events
 type ApplicationAcceptedHandler struct{}
 
-// NewApplicationAcceptedHandler creates a new ApplicationAcceptedHandler
 func NewApplicationAcceptedHandler() *ApplicationAcceptedHandler {
 	return &ApplicationAcceptedHandler{}
 }
 
-// Handle processes an APPLICATION_ACCEPTED event
 func (h *ApplicationAcceptedHandler) Handle(ctx context.Context, b *bot.DiscordBot, guildID string, payload map[string]interface{}) (map[string]interface{}, error) {
 	return handleApplicationNotification(b, payload, bot.StatusAccepted)
 }
@@ -39,12 +35,10 @@ func (h *ApplicationAcceptedHandler) Handle(ctx context.Context, b *bot.DiscordB
 // ApplicationRejectedHandler handles APPLICATION_REJECTED events
 type ApplicationRejectedHandler struct{}
 
-// NewApplicationRejectedHandler creates a new ApplicationRejectedHandler
 func NewApplicationRejectedHandler() *ApplicationRejectedHandler {
 	return &ApplicationRejectedHandler{}
 }
 
-// Handle processes an APPLICATION_REJECTED event
 func (h *ApplicationRejectedHandler) Handle(ctx context.Context, b *bot.DiscordBot, guildID string, payload map[string]interface{}) (map[string]interface{}, error) {
 	return handleApplicationNotification(b, payload, bot.StatusRejected)
 }
@@ -57,9 +51,37 @@ func NewApplicationCancelledHandler() *ApplicationCancelledHandler {
 }
 
 func (h *ApplicationCancelledHandler) Handle(ctx context.Context, b *bot.DiscordBot, guildID string, payload map[string]interface{}) (map[string]interface{}, error) {
-	// TODO: Discord 알림 전송 로직
-	slog.Info("ApplicationCancelledHandler invoked", "guild_id", guildID)
-	return nil, nil
+	var event models.ContestApplicationEventPayload
+	if err := unmarshalPayload(payload, &event); err != nil {
+		return nil, err
+	}
+
+	if event.DiscordTextChannelID == "" {
+		slog.Warn("application.cancelled: discord_text_channel_id is empty, skipping")
+		return nil, nil
+	}
+	if event.DiscordUserID == "" {
+		slog.Warn("application.cancelled: discord_user_id is empty, skipping")
+		return nil, nil
+	}
+
+	contestTitle, _ := event.Data["contest_title"].(string)
+	if contestTitle == "" {
+		contestTitle = "不明な大会"
+	}
+
+	content := fmt.Sprintf(
+		"**[申請取消]**\n\n"+
+			"<@%s>様が **%s** 大会への参加申請を取り消しました。",
+		event.DiscordUserID, contestTitle,
+	)
+
+	result, err := b.SendMessage(event.DiscordTextChannelID, content)
+	if err != nil {
+		return nil, fmt.Errorf("application.cancelled: failed to send message: %w", err)
+	}
+
+	return marshalResult(result)
 }
 
 // MemberWithdrawnHandler handles member.withdrawn events
@@ -70,14 +92,41 @@ func NewMemberWithdrawnHandler() *MemberWithdrawnHandler {
 }
 
 func (h *MemberWithdrawnHandler) Handle(ctx context.Context, b *bot.DiscordBot, guildID string, payload map[string]interface{}) (map[string]interface{}, error) {
-	// TODO: Discord 알림 전송 로직
-	slog.Info("MemberWithdrawnHandler invoked", "guild_id", guildID)
-	return nil, nil
+	var event models.ContestApplicationEventPayload
+	if err := unmarshalPayload(payload, &event); err != nil {
+		return nil, err
+	}
+
+	if event.DiscordTextChannelID == "" {
+		slog.Warn("member.withdrawn: discord_text_channel_id is empty, skipping")
+		return nil, nil
+	}
+	if event.DiscordUserID == "" {
+		slog.Warn("member.withdrawn: discord_user_id is empty, skipping")
+		return nil, nil
+	}
+
+	contestTitle, _ := event.Data["contest_title"].(string)
+	if contestTitle == "" {
+		contestTitle = "不明な大会"
+	}
+
+	content := fmt.Sprintf(
+		"**[参加辞退]**\n\n"+
+			"<@%s>様が **%s** 大会への参加を辞退しました。",
+		event.DiscordUserID, contestTitle,
+	)
+
+	result, err := b.SendMessage(event.DiscordTextChannelID, content)
+	if err != nil {
+		return nil, fmt.Errorf("member.withdrawn: failed to send message: %w", err)
+	}
+
+	return marshalResult(result)
 }
 
 // handleApplicationNotification is a shared function for handling application notifications
 func handleApplicationNotification(b *bot.DiscordBot, payload map[string]interface{}, status bot.ApplicationStatus) (map[string]interface{}, error) {
-	// Parse payload to ContestApplicationEventPayload
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal payload: %w", err)
@@ -88,30 +137,29 @@ func handleApplicationNotification(b *bot.DiscordBot, payload map[string]interfa
 		return nil, fmt.Errorf("failed to unmarshal payload: %w", err)
 	}
 
-	// Get channel ID from DiscordTextChannelID field
 	channelID := eventPayload.DiscordTextChannelID
 	if channelID == "" {
-		return nil, fmt.Errorf("discord_text_channel_id is required")
+		slog.Warn("application notification: discord_text_channel_id is empty, skipping",
+			"status", status)
+		return nil, nil
 	}
 
-	// Validate required fields
 	if eventPayload.DiscordUserID == "" {
-		return nil, fmt.Errorf("discord_user_id is required")
+		slog.Warn("application notification: discord_user_id is empty, skipping",
+			"status", status)
+		return nil, nil
 	}
 
-	// Extract contest_title from Data
 	contestTitle, _ := eventPayload.Data["contest_title"].(string)
 	if contestTitle == "" {
-		return nil, fmt.Errorf("contest_title is required in data")
+		contestTitle = "不明な大会"
 	}
 
-	// Extract processed_by_discord_id for accepted/rejected events
 	var processedByDiscordID string
 	if status == bot.StatusAccepted || status == bot.StatusRejected {
 		processedByDiscordID, _ = eventPayload.Data["processed_by_discord_id"].(string)
 	}
 
-	// Send application notification
 	result, err := b.SendApplicationNotification(
 		channelID,
 		eventPayload.DiscordUserID,
@@ -123,16 +171,5 @@ func handleApplicationNotification(b *bot.DiscordBot, payload map[string]interfa
 		return nil, err
 	}
 
-	// Convert result to map
-	resultBytes, err := json.Marshal(result)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal result: %w", err)
-	}
-
-	var resultMap map[string]interface{}
-	if err := json.Unmarshal(resultBytes, &resultMap); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal result: %w", err)
-	}
-
-	return resultMap, nil
+	return marshalResult(result)
 }

--- a/internal/handlers/game.go
+++ b/internal/handlers/game.go
@@ -2,9 +2,11 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/gamers-bot/internal/bot"
+	"github.com/gamers-bot/internal/models"
 )
 
 // GameScheduledHandler handles game.scheduled events
@@ -15,9 +17,29 @@ func NewGameScheduledHandler() *GameScheduledHandler {
 }
 
 func (h *GameScheduledHandler) Handle(ctx context.Context, b *bot.DiscordBot, guildID string, payload map[string]interface{}) (map[string]interface{}, error) {
-	// TODO: Discord 알림 전송 로직
-	slog.Info("GameScheduledHandler invoked", "guild_id", guildID)
-	return nil, nil
+	var event models.GameEventPayload
+	if err := unmarshalPayload(payload, &event); err != nil {
+		return nil, err
+	}
+
+	if event.DiscordTextChannelID == "" {
+		slog.Warn("game.scheduled: discord_text_channel_id is empty, skipping", "game_id", event.GameID)
+		return nil, nil
+	}
+
+	content := fmt.Sprintf(
+		"**[試合予定]**\n\n"+
+			"試合(ID: %d)がスケジュールされました。\n"+
+			"開始時間に備えてお待ちください！",
+		event.GameID,
+	)
+
+	result, err := b.SendMessage(event.DiscordTextChannelID, content)
+	if err != nil {
+		return nil, fmt.Errorf("game.scheduled: failed to send message: %w", err)
+	}
+
+	return marshalResult(result)
 }
 
 // GameActivatedHandler handles game.activated events
@@ -28,9 +50,29 @@ func NewGameActivatedHandler() *GameActivatedHandler {
 }
 
 func (h *GameActivatedHandler) Handle(ctx context.Context, b *bot.DiscordBot, guildID string, payload map[string]interface{}) (map[string]interface{}, error) {
-	// TODO: Discord 알림 전송 로직
-	slog.Info("GameActivatedHandler invoked", "guild_id", guildID)
-	return nil, nil
+	var event models.GameEventPayload
+	if err := unmarshalPayload(payload, &event); err != nil {
+		return nil, err
+	}
+
+	if event.DiscordTextChannelID == "" {
+		slog.Warn("game.activated: discord_text_channel_id is empty, skipping", "game_id", event.GameID)
+		return nil, nil
+	}
+
+	content := fmt.Sprintf(
+		"**[試合開始]**\n\n"+
+			"試合(ID: %d)が開始されました！\n"+
+			"頑張ってください！",
+		event.GameID,
+	)
+
+	result, err := b.SendMessage(event.DiscordTextChannelID, content)
+	if err != nil {
+		return nil, fmt.Errorf("game.activated: failed to send message: %w", err)
+	}
+
+	return marshalResult(result)
 }
 
 // GameMatchDetectingHandler handles game.match.detecting events
@@ -41,9 +83,29 @@ func NewGameMatchDetectingHandler() *GameMatchDetectingHandler {
 }
 
 func (h *GameMatchDetectingHandler) Handle(ctx context.Context, b *bot.DiscordBot, guildID string, payload map[string]interface{}) (map[string]interface{}, error) {
-	// TODO: Discord 알림 전송 로직
-	slog.Info("GameMatchDetectingHandler invoked", "guild_id", guildID)
-	return nil, nil
+	var event models.GameEventPayload
+	if err := unmarshalPayload(payload, &event); err != nil {
+		return nil, err
+	}
+
+	if event.DiscordTextChannelID == "" {
+		slog.Warn("game.match.detecting: discord_text_channel_id is empty, skipping", "game_id", event.GameID)
+		return nil, nil
+	}
+
+	content := fmt.Sprintf(
+		"**[マッチ検出中]**\n\n"+
+			"試合(ID: %d)のマッチ検出を行っています...\n"+
+			"しばらくお待ちください。",
+		event.GameID,
+	)
+
+	result, err := b.SendMessage(event.DiscordTextChannelID, content)
+	if err != nil {
+		return nil, fmt.Errorf("game.match.detecting: failed to send message: %w", err)
+	}
+
+	return marshalResult(result)
 }
 
 // GameMatchDetectedHandler handles game.match.detected events
@@ -54,9 +116,28 @@ func NewGameMatchDetectedHandler() *GameMatchDetectedHandler {
 }
 
 func (h *GameMatchDetectedHandler) Handle(ctx context.Context, b *bot.DiscordBot, guildID string, payload map[string]interface{}) (map[string]interface{}, error) {
-	// TODO: Discord 알림 전송 로직
-	slog.Info("GameMatchDetectedHandler invoked", "guild_id", guildID)
-	return nil, nil
+	var event models.GameEventPayload
+	if err := unmarshalPayload(payload, &event); err != nil {
+		return nil, err
+	}
+
+	if event.DiscordTextChannelID == "" {
+		slog.Warn("game.match.detected: discord_text_channel_id is empty, skipping", "game_id", event.GameID)
+		return nil, nil
+	}
+
+	content := fmt.Sprintf(
+		"**[マッチ検出完了]**\n\n"+
+			"試合(ID: %d)のマッチが正常に検出されました！",
+		event.GameID,
+	)
+
+	result, err := b.SendMessage(event.DiscordTextChannelID, content)
+	if err != nil {
+		return nil, fmt.Errorf("game.match.detected: failed to send message: %w", err)
+	}
+
+	return marshalResult(result)
 }
 
 // GameMatchFailedHandler handles game.match.failed events
@@ -67,9 +148,29 @@ func NewGameMatchFailedHandler() *GameMatchFailedHandler {
 }
 
 func (h *GameMatchFailedHandler) Handle(ctx context.Context, b *bot.DiscordBot, guildID string, payload map[string]interface{}) (map[string]interface{}, error) {
-	// TODO: Discord 알림 전송 로직
-	slog.Info("GameMatchFailedHandler invoked", "guild_id", guildID)
-	return nil, nil
+	var event models.GameEventPayload
+	if err := unmarshalPayload(payload, &event); err != nil {
+		return nil, err
+	}
+
+	if event.DiscordTextChannelID == "" {
+		slog.Warn("game.match.failed: discord_text_channel_id is empty, skipping", "game_id", event.GameID)
+		return nil, nil
+	}
+
+	content := fmt.Sprintf(
+		"**[マッチ検出失敗]**\n\n"+
+			"試合(ID: %d)のマッチ検出に失敗しました。\n"+
+			"運営人に確認をお願いします。",
+		event.GameID,
+	)
+
+	result, err := b.SendMessage(event.DiscordTextChannelID, content)
+	if err != nil {
+		return nil, fmt.Errorf("game.match.failed: failed to send message: %w", err)
+	}
+
+	return marshalResult(result)
 }
 
 // GameFinishedHandler handles game.finished events
@@ -80,9 +181,29 @@ func NewGameFinishedHandler() *GameFinishedHandler {
 }
 
 func (h *GameFinishedHandler) Handle(ctx context.Context, b *bot.DiscordBot, guildID string, payload map[string]interface{}) (map[string]interface{}, error) {
-	// TODO: Discord 알림 전송 로직
-	slog.Info("GameFinishedHandler invoked", "guild_id", guildID)
-	return nil, nil
+	var event models.GameEventPayload
+	if err := unmarshalPayload(payload, &event); err != nil {
+		return nil, err
+	}
+
+	if event.DiscordTextChannelID == "" {
+		slog.Warn("game.finished: discord_text_channel_id is empty, skipping", "game_id", event.GameID)
+		return nil, nil
+	}
+
+	content := fmt.Sprintf(
+		"**[試合終了]**\n\n"+
+			"試合(ID: %d)が終了しました。\n"+
+			"お疲れ様でした！",
+		event.GameID,
+	)
+
+	result, err := b.SendMessage(event.DiscordTextChannelID, content)
+	if err != nil {
+		return nil, fmt.Errorf("game.finished: failed to send message: %w", err)
+	}
+
+	return marshalResult(result)
 }
 
 // ContestTeamsReadyHandler handles game.contest.teams.ready events
@@ -93,7 +214,27 @@ func NewContestTeamsReadyHandler() *ContestTeamsReadyHandler {
 }
 
 func (h *ContestTeamsReadyHandler) Handle(ctx context.Context, b *bot.DiscordBot, guildID string, payload map[string]interface{}) (map[string]interface{}, error) {
-	// TODO: Discord 알림 전송 로직
-	slog.Info("ContestTeamsReadyHandler invoked", "guild_id", guildID)
-	return nil, nil
+	var event models.ContestTeamsReadyPayload
+	if err := unmarshalPayload(payload, &event); err != nil {
+		return nil, err
+	}
+
+	if event.DiscordTextChannelID == "" {
+		slog.Warn("game.contest.teams.ready: discord_text_channel_id is empty, skipping", "contest_id", event.ContestID)
+		return nil, nil
+	}
+
+	content := fmt.Sprintf(
+		"**[チーム準備完了]**\n\n"+
+			"大会の全チーム(%d チーム)が準備完了しました！\n"+
+			"まもなく試合が開始されます。",
+		event.TeamCount,
+	)
+
+	result, err := b.SendMessage(event.DiscordTextChannelID, content)
+	if err != nil {
+		return nil, fmt.Errorf("game.contest.teams.ready: failed to send message: %w", err)
+	}
+
+	return marshalResult(result)
 }

--- a/internal/handlers/team.go
+++ b/internal/handlers/team.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 
 	"github.com/gamers-bot/internal/bot"
 	"github.com/gamers-bot/internal/models"
@@ -14,7 +15,6 @@ import (
 // TeamInviteSentHandler handles team.invite.sent events
 type TeamInviteSentHandler struct{}
 
-// NewTeamInviteSentHandler creates a new TeamInviteSentHandler
 func NewTeamInviteSentHandler() *TeamInviteSentHandler {
 	return &TeamInviteSentHandler{}
 }
@@ -26,15 +26,15 @@ func (h *TeamInviteSentHandler) Handle(ctx context.Context, b *bot.DiscordBot, g
 		return nil, err
 	}
 
-	// Validate required fields
 	if eventPayload.InviteeDiscordID == "" {
-		return nil, fmt.Errorf("invitee_discord_id is required")
+		slog.Warn("team.invite.sent: invitee_discord_id is empty, skipping")
+		return nil, nil
 	}
 	if eventPayload.TeamName == "" {
-		return nil, fmt.Errorf("team_name is required")
+		slog.Warn("team.invite.sent: team_name is empty, skipping")
+		return nil, nil
 	}
 
-	// Build DM content
 	content := fmt.Sprintf(
 		"**[チーム招待]**\n\n"+
 			"**%s**さんから **%s** チームに招待されました。\n"+
@@ -54,7 +54,6 @@ func (h *TeamInviteSentHandler) Handle(ctx context.Context, b *bot.DiscordBot, g
 // TeamInviteAcceptedHandler handles team.invite.accepted events
 type TeamInviteAcceptedHandler struct{}
 
-// NewTeamInviteAcceptedHandler creates a new TeamInviteAcceptedHandler
 func NewTeamInviteAcceptedHandler() *TeamInviteAcceptedHandler {
 	return &TeamInviteAcceptedHandler{}
 }
@@ -66,15 +65,15 @@ func (h *TeamInviteAcceptedHandler) Handle(ctx context.Context, b *bot.DiscordBo
 		return nil, err
 	}
 
-	// Validate required fields
 	if eventPayload.DiscordTextChannelID == "" {
-		return nil, fmt.Errorf("discord_text_channel_id is required")
+		slog.Warn("team.invite.accepted: discord_text_channel_id is empty, skipping")
+		return nil, nil
 	}
 	if eventPayload.InviteeDiscordID == "" {
-		return nil, fmt.Errorf("invitee_discord_id is required")
+		slog.Warn("team.invite.accepted: invitee_discord_id is empty, skipping")
+		return nil, nil
 	}
 
-	// Send notification to team channel
 	result, err := b.SendTeamInviteNotification(
 		eventPayload.DiscordTextChannelID,
 		eventPayload.InviterDiscordID,
@@ -94,7 +93,6 @@ func (h *TeamInviteAcceptedHandler) Handle(ctx context.Context, b *bot.DiscordBo
 // TeamInviteRejectedHandler handles team.invite.rejected events
 type TeamInviteRejectedHandler struct{}
 
-// NewTeamInviteRejectedHandler creates a new TeamInviteRejectedHandler
 func NewTeamInviteRejectedHandler() *TeamInviteRejectedHandler {
 	return &TeamInviteRejectedHandler{}
 }
@@ -106,12 +104,11 @@ func (h *TeamInviteRejectedHandler) Handle(ctx context.Context, b *bot.DiscordBo
 		return nil, err
 	}
 
-	// Validate required fields
 	if eventPayload.InviterDiscordID == "" {
-		return nil, fmt.Errorf("inviter_discord_id is required")
+		slog.Warn("team.invite.rejected: inviter_discord_id is empty, skipping")
+		return nil, nil
 	}
 
-	// Build DM content for team leader
 	content := fmt.Sprintf(
 		"**[招待拒否]**\n\n"+
 			"**%s**さんが **%s** チームへの招待を拒否しました。",
@@ -132,7 +129,6 @@ func (h *TeamInviteRejectedHandler) Handle(ctx context.Context, b *bot.DiscordBo
 // TeamMemberJoinedHandler handles team.member.joined events
 type TeamMemberJoinedHandler struct{}
 
-// NewTeamMemberJoinedHandler creates a new TeamMemberJoinedHandler
 func NewTeamMemberJoinedHandler() *TeamMemberJoinedHandler {
 	return &TeamMemberJoinedHandler{}
 }
@@ -144,15 +140,15 @@ func (h *TeamMemberJoinedHandler) Handle(ctx context.Context, b *bot.DiscordBot,
 		return nil, err
 	}
 
-	// Validate required fields
 	if eventPayload.DiscordTextChannelID == "" {
-		return nil, fmt.Errorf("discord_text_channel_id is required")
+		slog.Warn("team.member.joined: discord_text_channel_id is empty, skipping")
+		return nil, nil
 	}
 	if eventPayload.DiscordUserID == "" {
-		return nil, fmt.Errorf("discord_user_id is required")
+		slog.Warn("team.member.joined: discord_user_id is empty, skipping")
+		return nil, nil
 	}
 
-	// Send notification to team channel
 	result, err := b.SendTeamMemberNotification(
 		eventPayload.DiscordTextChannelID,
 		eventPayload.DiscordUserID,
@@ -171,7 +167,6 @@ func (h *TeamMemberJoinedHandler) Handle(ctx context.Context, b *bot.DiscordBot,
 // TeamMemberLeftHandler handles team.member.left events
 type TeamMemberLeftHandler struct{}
 
-// NewTeamMemberLeftHandler creates a new TeamMemberLeftHandler
 func NewTeamMemberLeftHandler() *TeamMemberLeftHandler {
 	return &TeamMemberLeftHandler{}
 }
@@ -183,12 +178,11 @@ func (h *TeamMemberLeftHandler) Handle(ctx context.Context, b *bot.DiscordBot, g
 		return nil, err
 	}
 
-	// Validate required fields
 	if eventPayload.DiscordTextChannelID == "" {
-		return nil, fmt.Errorf("discord_text_channel_id is required")
+		slog.Warn("team.member.left: discord_text_channel_id is empty, skipping")
+		return nil, nil
 	}
 
-	// Send notification to team channel
 	result, err := b.SendTeamMemberNotification(
 		eventPayload.DiscordTextChannelID,
 		eventPayload.DiscordUserID,
@@ -207,7 +201,6 @@ func (h *TeamMemberLeftHandler) Handle(ctx context.Context, b *bot.DiscordBot, g
 // TeamMemberKickedHandler handles team.member.kicked events
 type TeamMemberKickedHandler struct{}
 
-// NewTeamMemberKickedHandler creates a new TeamMemberKickedHandler
 func NewTeamMemberKickedHandler() *TeamMemberKickedHandler {
 	return &TeamMemberKickedHandler{}
 }
@@ -219,12 +212,11 @@ func (h *TeamMemberKickedHandler) Handle(ctx context.Context, b *bot.DiscordBot,
 		return nil, err
 	}
 
-	// Validate required fields
 	if eventPayload.DiscordUserID == "" {
-		return nil, fmt.Errorf("discord_user_id is required")
+		slog.Warn("team.member.kicked: discord_user_id is empty, skipping")
+		return nil, nil
 	}
 
-	// Build DM content for kicked user
 	content := "**[チーム強制退出]**\n\n" +
 		"チームから退出されました。\n" +
 		"詳しい内容はチームリーダーにお問い合わせください。"
@@ -243,7 +235,6 @@ func (h *TeamMemberKickedHandler) Handle(ctx context.Context, b *bot.DiscordBot,
 // TeamLeadershipTransferredHandler handles team.leadership.transferred events
 type TeamLeadershipTransferredHandler struct{}
 
-// NewTeamLeadershipTransferredHandler creates a new TeamLeadershipTransferredHandler
 func NewTeamLeadershipTransferredHandler() *TeamLeadershipTransferredHandler {
 	return &TeamLeadershipTransferredHandler{}
 }
@@ -255,15 +246,15 @@ func (h *TeamLeadershipTransferredHandler) Handle(ctx context.Context, b *bot.Di
 		return nil, err
 	}
 
-	// Validate required fields
 	if eventPayload.DiscordTextChannelID == "" {
-		return nil, fmt.Errorf("discord_text_channel_id is required")
+		slog.Warn("team.leadership.transferred: discord_text_channel_id is empty, skipping")
+		return nil, nil
 	}
 	if eventPayload.LeaderDiscordID == "" {
-		return nil, fmt.Errorf("leader_discord_id is required")
+		slog.Warn("team.leadership.transferred: leader_discord_id is empty, skipping")
+		return nil, nil
 	}
 
-	// Send notification to team channel
 	result, err := b.SendTeamStatusNotification(
 		eventPayload.DiscordTextChannelID,
 		eventPayload.LeaderDiscordID,
@@ -280,7 +271,6 @@ func (h *TeamLeadershipTransferredHandler) Handle(ctx context.Context, b *bot.Di
 // TeamFinalizedHandler handles team.finalized events
 type TeamFinalizedHandler struct{}
 
-// NewTeamFinalizedHandler creates a new TeamFinalizedHandler
 func NewTeamFinalizedHandler() *TeamFinalizedHandler {
 	return &TeamFinalizedHandler{}
 }
@@ -292,15 +282,15 @@ func (h *TeamFinalizedHandler) Handle(ctx context.Context, b *bot.DiscordBot, gu
 		return nil, err
 	}
 
-	// Validate required fields
 	if eventPayload.DiscordTextChannelID == "" {
-		return nil, fmt.Errorf("discord_text_channel_id is required")
+		slog.Warn("team.finalized: discord_text_channel_id is empty, skipping")
+		return nil, nil
 	}
 	if eventPayload.LeaderDiscordID == "" {
-		return nil, fmt.Errorf("leader_discord_id is required")
+		slog.Warn("team.finalized: leader_discord_id is empty, skipping")
+		return nil, nil
 	}
 
-	// Send notification to team channel
 	result, err := b.SendTeamStatusNotification(
 		eventPayload.DiscordTextChannelID,
 		eventPayload.LeaderDiscordID,
@@ -317,7 +307,6 @@ func (h *TeamFinalizedHandler) Handle(ctx context.Context, b *bot.DiscordBot, gu
 // TeamDeletedHandler handles team.deleted events
 type TeamDeletedHandler struct{}
 
-// NewTeamDeletedHandler creates a new TeamDeletedHandler
 func NewTeamDeletedHandler() *TeamDeletedHandler {
 	return &TeamDeletedHandler{}
 }
@@ -329,12 +318,11 @@ func (h *TeamDeletedHandler) Handle(ctx context.Context, b *bot.DiscordBot, guil
 		return nil, err
 	}
 
-	// Validate required fields
 	if eventPayload.DiscordTextChannelID == "" {
-		return nil, fmt.Errorf("discord_text_channel_id is required")
+		slog.Warn("team.deleted: discord_text_channel_id is empty, skipping")
+		return nil, nil
 	}
 
-	// Send notification to team channel
 	result, err := b.SendTeamStatusNotification(
 		eventPayload.DiscordTextChannelID,
 		eventPayload.LeaderDiscordID,

--- a/internal/rabbitmq/dedup.go
+++ b/internal/rabbitmq/dedup.go
@@ -1,0 +1,67 @@
+package rabbitmq
+
+import (
+	"sync"
+	"time"
+)
+
+// DedupCache is an in-memory cache that tracks processed event_ids
+// to prevent duplicate event handling (idempotency).
+// Entries expire after the configured TTL to avoid unbounded memory growth.
+//
+// For production at scale, consider replacing this with a Redis-based
+// implementation (e.g. SET event_id EX 3600 NX) for cross-instance dedup.
+type DedupCache struct {
+	mu      sync.Mutex
+	entries map[string]time.Time
+	ttl     time.Duration
+}
+
+// NewDedupCache creates a new DedupCache with the given TTL for entries.
+// It starts a background goroutine that periodically evicts expired entries.
+func NewDedupCache(ttl time.Duration) *DedupCache {
+	c := &DedupCache{
+		entries: make(map[string]time.Time),
+		ttl:     ttl,
+	}
+	go c.evictLoop()
+	return c
+}
+
+// IsDuplicate returns true if the eventID has already been seen (and is not expired).
+// If it has not been seen, it marks it as seen and returns false.
+func (c *DedupCache) IsDuplicate(eventID string) bool {
+	if eventID == "" {
+		// No event_id means we cannot deduplicate; treat as unique.
+		return false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if ts, ok := c.entries[eventID]; ok {
+		if time.Since(ts) < c.ttl {
+			return true
+		}
+		// Expired entry, allow re-processing
+	}
+	c.entries[eventID] = time.Now()
+	return false
+}
+
+// evictLoop removes expired entries every ttl/2 interval.
+func (c *DedupCache) evictLoop() {
+	ticker := time.NewTicker(c.ttl / 2)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		c.mu.Lock()
+		now := time.Now()
+		for id, ts := range c.entries {
+			if now.Sub(ts) >= c.ttl {
+				delete(c.entries, id)
+			}
+		}
+		c.mu.Unlock()
+	}
+}

--- a/internal/rabbitmq/topology.go
+++ b/internal/rabbitmq/topology.go
@@ -6,34 +6,16 @@ type QueueBinding struct {
 	RoutingKeys []string
 }
 
-// DefaultQueueBindings returns the 4 new queue bindings for the gamers.events exchange
+// DefaultQueueBindings returns the unified notification queue binding for the gamers.events exchange.
+// All notification events are consumed from a single dedicated queue: discord.bot.notifications.
 func DefaultQueueBindings() []QueueBinding {
 	return []QueueBinding{
 		{
-			QueueName: "bot.contest.notifications",
+			QueueName: "discord.bot.notifications",
 			RoutingKeys: []string{
 				"contest.#",
-			},
-		},
-		{
-			QueueName: "bot.team.notifications",
-			RoutingKeys: []string{
 				"game.team.#",
-			},
-		},
-		{
-			QueueName: "bot.game.notifications",
-			RoutingKeys: []string{
-				"game.scheduled",
-				"game.activated",
-				"game.match.*",
-				"game.finished",
-			},
-		},
-		{
-			QueueName: "bot.contest.teams.ready",
-			RoutingKeys: []string{
-				"game.contest.teams.ready",
+				"game.game.#",
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- Consolidate 4 separate queues into a single `discord.bot.notifications` queue with bindings: `contest.#`, `game.team.#`, `game.game.#`
- Introduce `DedupCache` (in-memory, 1h TTL) for `event_id`-based duplicate event prevention
- Improve ACK/NACK policy: handler errors → `Nack(requeue=true)`, malformed messages → `Nack(requeue=false)`
- Implement all 10 remaining TODO handlers (contest, game, application events)
- Unify validation across all handlers: missing required IDs → log warning + skip (no panics)

## Changed Files
| File | Description |
|---|---|
| `internal/rabbitmq/topology.go` | 4 queues → 1 queue (`discord.bot.notifications`) |
| `internal/rabbitmq/dedup.go` | **New** — in-memory idempotency cache |
| `internal/rabbitmq/consumer.go` | Integrate dedup, improve ACK/NACK, remove unused helpers |
| `internal/handlers/contest.go` | Implement `contest.created`, add `unmarshalPayload` helper |
| `internal/handlers/game.go` | Implement all 7 game lifecycle handlers |
| `internal/handlers/application.go` | Implement `application.cancelled`, `member.withdrawn`, improve validation |
| `internal/handlers/team.go` | Unify validation pattern (error return → log + skip) |

## Test plan
- [ ] `go build ./...` and `go vet ./...` pass
- [ ] Publish each event type to RabbitMQ and verify Discord message delivery
- [ ] Publish duplicate `event_id` and verify the second message is skipped
- [ ] Publish event with missing `discord_text_channel_id` and verify log + skip behavior
- [ ] Verify handler errors trigger message requeue (`Nack requeue=true`)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)